### PR TITLE
h265nal: check that nal unit parser can deal with empty buffers

### DIFF
--- a/test/h265_nal_unit_parser_unittest.cc
+++ b/test/h265_nal_unit_parser_unittest.cc
@@ -110,4 +110,12 @@ TEST_F(H265NalUnitParserTest, TestSampleNalUnit) {
   EXPECT_EQ(0, vps->vps_extension_data_flag);
 }
 
+TEST_F(H265NalUnitParserTest, TestEmptyNalUnit) {
+  const uint8_t buffer[] = {};
+  H265BitstreamParserState bitstream_parser_state;
+  auto nal_unit = H265NalUnitParser::ParseNalUnit(buffer, 0,
+                                                  &bitstream_parser_state);
+  EXPECT_TRUE(nal_unit == nullptr);
+}
+
 }  // namespace h265nal


### PR DESCRIPTION
Added a unittest.

Tested:

```
$ ./test/h265_nal_unit_parser_unittest
Running main() from /builddir/build/BUILD/googletest-release-1.10.0/googletest/src/gtest_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from H265NalUnitParserTest
[ RUN      ] H265NalUnitParserTest.TestSampleNalUnit
[       OK ] H265NalUnitParserTest.TestSampleNalUnit (0 ms)
[ RUN      ] H265NalUnitParserTest.TestEmptyNalUnit
error: cannot ParseNalUnitHeader in nal unit
[       OK ] H265NalUnitParserTest.TestEmptyNalUnit (1 ms)
[----------] 2 tests from H265NalUnitParserTest (1 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 2 tests.
```